### PR TITLE
Fix hash modification while iterating

### DIFF
--- a/lib/multi_process.rb
+++ b/lib/multi_process.rb
@@ -4,6 +4,7 @@ require 'childprocess'
 module MultiProcess
   DEFAULT_TIMEOUT = 60
 
+  require 'multi_process/loop'
   require 'multi_process/group'
   require 'multi_process/receiver'
   require 'multi_process/nil_receiver'

--- a/lib/multi_process/loop.rb
+++ b/lib/multi_process/loop.rb
@@ -1,0 +1,39 @@
+require 'nio'
+
+module MultiProcess
+  class Loop
+    def initialize
+      @selector = ::NIO::Selector.new
+
+      Thread.new do
+        loop do
+          @selector.select(30.0) do |monitor|
+            if monitor.io.eof?
+              @selector.deregister(monitor.io)
+              monitor.value.call(:eof, monitor)
+            else
+              monitor.value.call(:ready, monitor)
+            end
+          end
+
+          # Wait very short time to allow scheduling another thread
+          sleep(0.001)
+        end
+      end
+    end
+
+    def watch(io, &block)
+      @selector.wakeup
+      @selector.register(io, :r).tap do |monitor|
+        monitor.value = block
+        monitor.value.call(:registered, monitor)
+      end
+    end
+
+    class << self
+      def instance
+        @instance ||= new
+      end
+    end
+  end
+end

--- a/multi_process.gemspec
+++ b/multi_process.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '>= 3.1'
   spec.add_runtime_dependency 'childprocess'
+  spec.add_runtime_dependency 'nio4r', '~> 2.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler'
 end

--- a/spec/multi_process_spec.rb
+++ b/spec/multi_process_spec.rb
@@ -7,17 +7,17 @@ describe MultiProcess do
     logger = MultiProcess::Logger.new writer, collapse: false
     group  = MultiProcess::Group.new receiver: logger
     group << MultiProcess::Process.new(%w(ruby spec/files/test.rb A), title: 'rubyA')
-    group << MultiProcess::Process.new(%w(ruby spec/files/test.rb B), title: 'rubyB')
-    group << MultiProcess::Process.new(%w(ruby spec/files/test.rb C), title: 'rubyC')
+    group << MultiProcess::Process.new(%w(ruby spec/files/test.rb B), title: 'rubyBB')
+    group << MultiProcess::Process.new(%w(ruby spec/files/test.rb C), title: 'rubyCCC')
     group.run
 
-    expect(reader.read_nonblock(4096).split("\n")).to match_array <<-EOF.gsub(/^\s+/, ' ').split("\n")
-    rubyB  | Output from B
-    rubyA  | Output from A
-    rubyA  | Output from A
-    rubyC  | Output from C
-    rubyC  | Output from C
-    rubyB  | Output from B
+    expect(reader.read_nonblock(4096).split("\n")).to match_array <<-EOF.gsub(/^\s+\./, '').split("\n")
+    .  rubyBB  | Output from B
+    .   rubyA  | Output from A
+    .   rubyA  | Output from A
+    . rubyCCC  | Output from C
+    . rubyCCC  | Output from C
+    .  rubyBB  | Output from B
     EOF
   end
 


### PR DESCRIPTION
Fixes a rare concurrent hash access error by replacing the IO event loop with a new implementation and improving the logger receiver. See commits for more.