### PR TITLE
Switch from 127.0.0.1 to localhost

### DIFF
--- a/lib/multi_process/process/rails.rb
+++ b/lib/multi_process/process/rails.rb
@@ -44,7 +44,7 @@ class MultiProcess::Process
     def available?
       fail ArgumentError.new "Cannot check availability for port #{port}." if port == 0
 
-      TCPSocket.new('127.0.0.1', port).close
+      TCPSocket.new('localhost', port).close
       true
     rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
       false
@@ -67,7 +67,7 @@ class MultiProcess::Process
 
     def free_port
       socket = Socket.new(:INET, :STREAM, 0)
-      socket.bind(Addrinfo.tcp('127.0.0.1', 0))
+      socket.bind(Addrinfo.tcp('localhost', 0))
       socket.local_address.ip_port
     ensure
       socket.close if socket


### PR DESCRIPTION
The underlying OS will resolve the hostname `localhost` to `127.0.0.1` for IPv4 and to `::1` for IPv6 if properly configured.

This change is required to add full IPv6 support to this library and the applications using this gem.