### PR TITLE
Add release information for version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.1.0 - 2020-11-19
+### Feature
+-  Add support for IPv6 by using the hostname instead of the loopback IPv4 address (#2)
+
 ## 1.0.0 - 2019-05-13
 ### Fixed
 - Possible concurrent hash modification while iterating (#1)

--- a/lib/multi_process/version.rb
+++ b/lib/multi_process/version.rb
@@ -1,7 +1,7 @@
 module MultiProcess
   module VERSION
     MAJOR = 1
-    MINOR = 0
+    MINOR = 1
     PATCH = 0
     STAGE = nil
     STRING = [MAJOR, MINOR, PATCH, STAGE].reject(&:nil?).join('.')


### PR DESCRIPTION
We should release a new version on RubyGems.org and GitHub after merging