### PR TITLE
Use stdlib for method delegation instead of Active Support

### DIFF
--- a/lib/multi_process/process.rb
+++ b/lib/multi_process/process.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/module/delegation'
+require 'forwardable'
 
 module MultiProcess
   #
@@ -9,6 +9,8 @@ module MultiProcess
   # {Process} basically is just a thin wrapper around {ChildProcess}.
   #
   class Process
+    extend Forwardable
+
     # @!group Process
 
     # Process title used in e.g. logger
@@ -39,7 +41,7 @@ module MultiProcess
 
     # Delegate some methods to ChildProcess.
     #
-    delegate :exited?, :alive?, :crashed?, :exit_code, :pid, to: :childprocess
+    delegate [:exited?, :alive?, :crashed?, :exit_code, :pid] => :childprocess
 
     # Wait until process finished.
     #

--- a/multi_process.gemspec
+++ b/multi_process.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '>= 3.1'
   spec.add_runtime_dependency 'childprocess'
   spec.add_runtime_dependency 'nio4r', '~> 2.0'
 


### PR DESCRIPTION
It looks like the only thing Active Support is being used for is its method delegation functionality. Since this exists in Ruby's stdlib in a slightly different form, it seems reasonable to use that instead of depending on the whole of the large Active Support library.