### PR TITLE
Ensure the environment is actually clean

### DIFF
--- a/lib/multi_process/process.rb
+++ b/lib/multi_process/process.rb
@@ -159,7 +159,7 @@ module MultiProcess
     # Check if environment will be cleaned up for process.
     #
     # Currently that includes wrapping the process start in
-    # `Bundler.with_clean_env` to remove bundler environment
+    # `Bundler.with_unbundled_env` to remove bundler environment
     # variables.
     #
     def clean_env?
@@ -216,7 +216,7 @@ module MultiProcess
       childprocess.cwd = dir
 
       if clean_env?
-        Bundler.with_original_env { childprocess.start }
+        Bundler.with_unbundled_env { childprocess.start }
       else
         childprocess.start
       end


### PR DESCRIPTION
While `Bundler.with_original_env` will likely work in most circumstances, when spawning a process that also uses Bundler, the `BUNDLE_GEMFILE` environment variable will cause the spawned app to fail, since it will be looking for the `Gemfile` from the parent process instead of the child.