### PR TITLE
Fix adding a process after the group has been started

### DIFF
--- a/lib/multi_process/group.rb
+++ b/lib/multi_process/group.rb
@@ -42,7 +42,7 @@ module MultiProcess
         processes << process
         process.receiver = receiver
 
-        start process if started?
+        process.start if started?
       end
     end
 


### PR DESCRIPTION
This fixes an error that was occurring when adding a process after the group had been started.