### PR TITLE
Fix `Process#available!` error handling

### DIFF
--- a/lib/multi_process/group.rb
+++ b/lib/multi_process/group.rb
@@ -29,7 +29,7 @@ module MultiProcess
     def initialize(receiver: nil, partition: nil)
       @processes = []
       @receiver  = receiver || MultiProcess::Logger.global
-      @partition = partition ? partition.to_i : 0
+      @partition = partition ? Integer(partition) : 0
       @mutex     = Mutex.new
     end
 

--- a/lib/multi_process/group.rb
+++ b/lib/multi_process/group.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'timeout'
+
 module MultiProcess
   #
   # Store and run a group of processes.

--- a/lib/multi_process/process.rb
+++ b/lib/multi_process/process.rb
@@ -95,16 +95,16 @@ module MultiProcess
       childprocess.stop(*args) if started?
     end
 
-    # Check if server is available. What available means can be defined
-    # by subclasses e.g. a server process can check if server port is reachable.
+    # Check if the process is available. What available means can be defined
+    # by subclasses e.g. a server process can check if its port is reachable.
     #
-    # By default is process if available if alive? returns true.
+    # By default a process is available if `#alive?` returns true.
     #
     def available?
       alive?
     end
 
-    # Wait until process is available. See {#available?}.
+    # Wait until the process is available. See {#available?}.
     #
     # @param opts [Hash] Options.
     # @option opts [Integer] :timeout Timeout in seconds. Will raise
@@ -117,7 +117,7 @@ module MultiProcess
         sleep 0.2 until available?
       end
     rescue Timeout::Error
-      raise Timeout::Error.new "Server #{id.inspect} on port #{port} didn't get up after #{timeout} seconds..."
+      raise Timeout::Error.new "Process #{pid} failed to start."
     end
 
     # Check if process was started.

--- a/lib/multi_process/process.rb
+++ b/lib/multi_process/process.rb
@@ -111,7 +111,7 @@ module MultiProcess
     #  Timeout::Error if timeout is reached.
     #
     def available!(opts = {})
-      timeout = opts[:timeout] ? opts[:timeout].to_i : MultiProcess::DEFAULT_TIMEOUT
+      timeout = opts[:timeout] ? opts[:timeout].to_f : MultiProcess::DEFAULT_TIMEOUT
 
       Timeout.timeout timeout do
         sleep 0.2 until available?

--- a/lib/multi_process/process.rb
+++ b/lib/multi_process/process.rb
@@ -111,7 +111,7 @@ module MultiProcess
     #  Timeout::Error if timeout is reached.
     #
     def available!(opts = {})
-      timeout = opts[:timeout] ? opts[:timeout].to_f : MultiProcess::DEFAULT_TIMEOUT
+      timeout = opts[:timeout] ? Float(opts[:timeout]) : MultiProcess::DEFAULT_TIMEOUT
 
       Timeout.timeout timeout do
         sleep 0.2 until available?

--- a/lib/multi_process/process.rb
+++ b/lib/multi_process/process.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'forwardable'
+require 'timeout'
 
 module MultiProcess
   #

--- a/lib/multi_process/process/rails.rb
+++ b/lib/multi_process/process/rails.rb
@@ -30,7 +30,8 @@ class MultiProcess::Process
     end
 
     def port=(port)
-      @port = port.to_i.zero? ? free_port : port.to_i
+      port = Integer(port)
+      @port = port.zero? ? free_port : port
     end
 
     def port

--- a/spec/files/sleep.rb
+++ b/spec/files/sleep.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-sleep ARGV[0].to_i
+sleep ARGV[0].to_f

--- a/spec/files/sleep.rb
+++ b/spec/files/sleep.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-sleep ARGV[0].to_f
+sleep Float(ARGV[0])

--- a/spec/multi_process/process_spec.rb
+++ b/spec/multi_process/process_spec.rb
@@ -14,4 +14,16 @@ RSpec.describe MultiProcess::Process do
       end
     end
   end
+
+  describe '#available!' do
+    context 'when timeout is reached' do
+      let(:command) { %w[ruby spec/files/sleep.rb 2] }
+
+      it 'does raise an error' do
+        process.run!
+
+        expect { process.available! timeout: 1 }.to raise_error(Timeout::Error, /Process \d+ failed to start/)
+      end
+    end
+  end
 end

--- a/spec/multi_process/process_spec.rb
+++ b/spec/multi_process/process_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe MultiProcess::Process do
 
   describe '#available!' do
     context 'when timeout is reached' do
-      let(:command) { %w[ruby spec/files/sleep.rb 2] }
+      let(:command) { %w[ruby spec/files/sleep.rb 0.2] }
 
       it 'does raise an error' do
         process.run!
 
-        expect { process.available! timeout: 1 }.to raise_error(Timeout::Error, /Process \d+ failed to start/)
+        expect { process.available! timeout: 0.1 }.to raise_error(Timeout::Error, /Process \d+ failed to start/)
       end
     end
   end


### PR DESCRIPTION
- There were a couple references to undefined methods (`#id` and `#port`) in the error message raised by `Process#available?`. Use a simpler message that includes the `pid` instead and remove references to “server” since we’re working more generally with processes here.
- Allow float values to be used for timeouts on `Process#available?`.
- Ensure numeric values provided as strings are actually integers or floats as expected.