### PR TITLE
Find free port in a cross-platform way

### DIFF
--- a/lib/multi_process/process/rails.rb
+++ b/lib/multi_process/process/rails.rb
@@ -63,7 +63,7 @@ class MultiProcess::Process
 
     def free_port
       socket = Socket.new(:INET, :STREAM, 0)
-      socket.bind(Addrinfo.tcp('localhost', 0))
+      socket.bind(Addrinfo.tcp('127.0.0.1', 0))
       socket.local_address.ip_port
     ensure
       socket&.close


### PR DESCRIPTION
Use the more cross-platform friendly IP address instead of `localhost`, which raises errors under macOS.