### PR TITLE
Non-deterministic output causing intermittent spec failure

### DIFF
--- a/spec/multi_process_spec.rb
+++ b/spec/multi_process_spec.rb
@@ -48,8 +48,7 @@ describe MultiProcess do
     group << MultiProcess::Process.new(%w[ruby spec/files/test.rb 1], title: 'ruby1')
     group.start
     group << MultiProcess::Process.new(%w[ruby spec/files/test.rb 2], title: 'ruby2')
-    sleep 1
-    group.stop
+    group.wait
 
     expect(reader.read_nonblock(4096).split("\n")).to match_array <<-OUTPUT.gsub(/^\s+\./, '').split("\n")
     . ruby1  | Output from 1


### PR DESCRIPTION
The recently added (#11) spec `spec/multi_process_spec.rb:43` ("starts a process added after the group has been started") occasionally fails due to the order of the output lines changing. This doesn't appear to happen with the spec at `spec/multi_process_spec.rb:6` which is also non-deterministic, but I have not been able to produce an error on that spec; I'm not sure what would cause that one to work and this one to fail.

@jgraichen Thoughts?